### PR TITLE
Added View/Themed support

### DIFF
--- a/View/Helper/LessHelper.php
+++ b/View/Helper/LessHelper.php
@@ -37,8 +37,34 @@ class LessHelper extends AppHelper {
 		$this->lessFolder = new Folder(WWW_ROOT.'less');
 		$this->cssFolder = new Folder(WWW_ROOT.'css');
 	}
-
-	public function css($file) {
+	
+	/**
+	 * When called, will reset lessFolder for specific theme
+	 *
+	 * @note Note that it assumes themes are stored in app/View/Themed
+	 *
+	 * @param string $theme_name
+	 */
+	private function set_theme($theme_name) {
+  	
+  	
+    $app_root = array_filter(explode(DS, WWW_ROOT));
+    
+    array_pop($app_root);
+    $app_root = implode(DS, $app_root);
+    
+    $theme_path = DS.$app_root.DS.'View'.DS.'Themed'.DS.$theme_name.DS.'webroot'.DS;
+		$this->lessFolder = new Folder($theme_path.'less');
+		$this->cssFolder = new Folder($theme_path.'css');
+  	
+	}
+	
+	public function css($file, $options = array()) {
+	
+	 if (isset($options['theme']) and trim($options['theme'])) {
+  	 $this->set_theme($options['theme']);
+	 }
+	 
 		if (is_array($file)) {
 			foreach ($file as $candidate) {
 				$source = $this->lessFolder->path.DS.$candidate.'.less';


### PR DESCRIPTION
Added the method LessHelper::set_theme($theme_name) which is called from the (_updated_) LessHelper::css($file, $options = array());

**Example:**

Call the  LessHelper::css method normally, but with second $options array parameter -

`echo $this->Less->css('somefile', array('theme' => 'SomeTheme'));`

will parse:

`app/View/Themed/SomeTheme/webroot/less/somefile.less`

and output:

`<link rel="stylesheet" type="text/css" href="/theme/SomeTheme/css/somefile.css" />`
