### PR TITLE
Add support to files located in a plugin webroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Where you want to use LESS files, add the helper. Usually this will be your `App
 Next, simply add the less files to your views:
 
 	echo $this->Less->css('yourfile');
+
+or if the less file is located in the webroot of a plugin
+
+	echo $this->Less->css('yourfile',array('plugin' => 'PluginFolderName'));
 	
 or
 	

--- a/View/Helper/LessHelper.php
+++ b/View/Helper/LessHelper.php
@@ -68,6 +68,9 @@ class LessHelper extends AppHelper {
 				$this->auto_compile_less($source, $target);
 			}
 		} else {
+			if (isset($options['plugin']) and trim($options['plugin'])){
+				$this->lessFolder= new Folder(APP.'Plugin'.DS.$options['plugin'].DS.'webroot'.DS.'less');
+			}
 			$source = $this->lessFolder->path.DS.$file.'.less';
 			$target = str_replace('.less', '.css', str_replace($this->lessFolder->path, $this->cssFolder->path, $source));
 			$this->auto_compile_less($source, $target);


### PR DESCRIPTION
A simple workaround to load less files from a plugin. A better solution would be to support the cake convention 'Plugin.filename'. Another improvement to this nice utility
